### PR TITLE
When updating events, future occurrences will also be updated

### DIFF
--- a/backend/chore_tracker/views.py
+++ b/backend/chore_tracker/views.py
@@ -270,6 +270,8 @@ class UpdateEvent(APIView):
                 return JsonResponse(
                     {"success": False, "message": "Event not found"}, status=404
                 )
+            
+            delete_recurrences(event)
 
             # Update fields
             if "name" in data:
@@ -283,6 +285,7 @@ class UpdateEvent(APIView):
 
             event.save()
             logger.info("Event updated")
+            update_recurring_events(event.group)
             return JsonResponse({"success": True, "message": "Event updated"}, status=200)
 
         except JSONDecodeError:


### PR DESCRIPTION
This turned out to be a very simple fix using functions we already had. When updating an event, we simply:
(1) delete future occurrences of that event
(2) recreate the future occurrences but with the new settings

There is one catch here that if different group members were assigned to different occurrences of the event, these will be wiped out and reset to those assigned to the occurrence you are editing. I don't think it's a big deal but can look for a workaround if needed.